### PR TITLE
infra: migrate to shared Redis and move to humphrey.humfurie.org

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -33,12 +33,15 @@ return Application::configure(basePath: dirname(__DIR__))
             Request::HEADER_X_FORWARDED_AWS_ELB
         );
 
+        $middleware->web(prepend: [
+            CacheHeaders::class,
+        ]);
+
         $middleware->web(append: [
             AddRequestContext::class,
             HandleAppearance::class,
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,
-            CacheHeaders::class,
         ]);
 
         $middleware->api(append: [

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,15 +13,15 @@ services:
     env_file:
       - .env.production
     extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - 'host.docker.internal:host-gateway'
     environment:
       - APP_ENV=production
       - APP_DEBUG=false
       - DB_CONNECTION=pgsql
       - DB_HOST=shared-postgres
       - DB_PORT=5432
-      - REDIS_HOST=host.docker.internal
-      - REDIS_PORT=6380
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
       - QUEUE_CONNECTION=redis
       - CACHE_DRIVER=redis
       - SESSION_DRIVER=redis
@@ -29,49 +29,22 @@ services:
       - laravel
       - proxy
       - shared-postgres
+      - shared-redis
     labels:
-      - "traefik.enable=true"
-      - "traefik.docker.network=proxy"
-      - "traefik.http.services.humfurie.loadbalancer.server.port=80"
-      - "traefik.http.routers.humfurie.rule=Host(`humfurie.org`)"
-      - "traefik.http.routers.humfurie.entrypoints=websecure"
-      - "traefik.http.routers.humfurie.tls=true"
-      - "traefik.http.routers.humfurie.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.humfurie.middlewares=fallback-errors@file"
-      - "traefik.http.routers.humfurie-www.rule=Host(`www.humfurie.org`)"
-      - "traefik.http.routers.humfurie-www.entrypoints=websecure"
-      - "traefik.http.routers.humfurie-www.tls=true"
-      - "traefik.http.routers.humfurie-www.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.humfurie-www.middlewares=fallback-errors@file"
-    depends_on:
-      redis:
-        condition: service_healthy
+      - 'traefik.enable=true'
+      - 'traefik.docker.network=proxy'
+      - 'traefik.http.services.humphrey-humfurie.loadbalancer.server.port=80'
+      - 'traefik.http.routers.humphrey-humfurie.rule=Host(`humphrey.humfurie.org`)'
+      - 'traefik.http.routers.humphrey-humfurie.entrypoints=websecure'
+      - 'traefik.http.routers.humphrey-humfurie.tls=true'
+      - 'traefik.http.routers.humphrey-humfurie.tls.certresolver=letsencrypt'
+      - 'traefik.http.routers.humphrey-humfurie.middlewares=fallback-errors@file'
     deploy:
       resources:
         limits:
           memory: 1G
         reservations:
           memory: 512M
-
-  redis:
-    image: redis:7-alpine  # Specific version + Alpine
-    restart: unless-stopped
-    command: redis-server --maxmemory 256mb --maxmemory-policy allkeys-lru
-    ports:
-      - '6380:6379'
-    networks:
-      - laravel
-    healthcheck:
-      test: [ "CMD", "redis-cli", "ping" ]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-    deploy:
-      resources:
-        limits:
-          memory: 384M
-        reservations:
-          memory: 256M
 
   ssr:
     image: humfurie-app:latest
@@ -90,7 +63,7 @@ services:
       app:
         condition: service_started
     healthcheck:
-      test: [ "CMD-SHELL", "curl -sf http://localhost:13714/health || exit 1" ]
+      test: ['CMD-SHELL', 'curl -sf http://localhost:13714/health || exit 1']
       interval: 30s
       timeout: 10s
       retries: 3
@@ -114,7 +87,7 @@ services:
     networks:
       - laravel
     healthcheck:
-      test: [ "CMD-SHELL", "wget -qO- http://127.0.0.1:3001/health || exit 1" ]
+      test: ['CMD-SHELL', 'wget -qO- http://127.0.0.1:3001/health || exit 1']
       interval: 30s
       timeout: 10s
       retries: 3
@@ -133,6 +106,8 @@ networks:
     external: true
     name: proxy
   shared-postgres:
+    external: true
+  shared-redis:
     external: true
 
 volumes:


### PR DESCRIPTION
## Summary

- **Domain**: Move from `humfurie.org` to `humphrey.humfurie.org` subdomain, freeing the root domain for a future Rust backend
- **Shared Redis**: Remove per-app Redis container; connect to a shared external Redis instance via the `shared-redis` Docker network (mirrors the existing `shared-postgres` pattern)
- **Traefik**: Rename router/service labels from `humfurie` → `humphrey-humfurie`; remove www redirect router

## Server setup required before deploying

```bash
# Create shared Redis network and container (one-time)
docker network create shared-redis
docker run -d --name shared-redis \
  --network shared-redis \
  --restart unless-stopped \
  redis:7-alpine redis-server --maxmemory 256mb --maxmemory-policy allkeys-lru
```

Update `.env.production`:
```
REDIS_HOST=shared-redis
REDIS_PORT=6379
```

Also needed:
- Add `humphrey.humfurie.org` DNS record in Cloudflare
- Update `APP_URL` in `.env.production`
- Update Cloudflare Cache Rule host

## Test plan

- [ ] Shared Redis network exists on server before deploying
- [ ] `docker compose up` starts without errors (no redis service to wait for)
- [ ] App connects to Redis (queue, cache, session all working)
- [ ] `humphrey.humfurie.org` resolves and TLS cert is issued by Let's Encrypt
- [ ] `humfurie.org` can be freed for the Rust backend