### PR TITLE
feat: circular reveal theme toggle animation

### DIFF
--- a/resources/js/components/theme-toggle.tsx
+++ b/resources/js/components/theme-toggle.tsx
@@ -15,8 +15,11 @@ export default function ThemeToggle({ variant = 'icon-only', className = '' }: T
         return appearance === 'dark' || (appearance === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
     }, [appearance]);
 
-    const toggleTheme = () => {
-        updateAppearance(isDark ? 'light' : 'dark');
+    const toggleTheme = (e: React.MouseEvent<HTMLButtonElement>) => {
+        const rect = e.currentTarget.getBoundingClientRect();
+        const x = rect.left + rect.width / 2;
+        const y = rect.top + rect.height / 2;
+        updateAppearance(isDark ? 'light' : 'dark', x, y);
     };
 
     // Show current mode, not the mode we're switching to

--- a/resources/js/hooks/use-appearance.tsx
+++ b/resources/js/hooks/use-appearance.tsx
@@ -61,7 +61,7 @@ export function useAppearance() {
         return (localStorage.getItem('appearance') as Appearance) || 'system';
     });
 
-    const updateAppearance = useCallback((mode: Appearance) => {
+    const updateAppearance = useCallback((mode: Appearance, originX?: number, originY?: number) => {
         setAppearance(mode);
 
         // Store in localStorage for client-side persistence...
@@ -72,7 +72,18 @@ export function useAppearance() {
         // Store in cookie for SSR...
         setCookie('appearance', mode);
 
-        applyTheme(mode);
+        // Set CSS custom properties for the circular reveal origin point
+        if (originX !== undefined && originY !== undefined) {
+            document.documentElement.style.setProperty('--theme-toggle-x', `${originX}px`);
+            document.documentElement.style.setProperty('--theme-toggle-y', `${originY}px`);
+        }
+
+        if (typeof document !== 'undefined' && 'startViewTransition' in document) {
+            (document as Document & { startViewTransition: (cb: () => void) => void })
+                .startViewTransition(() => applyTheme(mode));
+        } else {
+            applyTheme(mode);
+        }
     }, []);
 
     useEffect(() => {

--- a/resources/js/styles/_keyframe-animations.scss
+++ b/resources/js/styles/_keyframe-animations.scss
@@ -104,3 +104,23 @@
 .animate-fade-in-down {
     animation: fadeInDown 0.3s ease-out;
 }
+
+/* ── Theme toggle: circular reveal via View Transition API ── */
+@keyframes theme-reveal {
+    from {
+        clip-path: circle(0% at var(--theme-toggle-x, 50%) var(--theme-toggle-y, 50%));
+    }
+    to {
+        clip-path: circle(150% at var(--theme-toggle-x, 50%) var(--theme-toggle-y, 50%));
+    }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    ::view-transition-old(root) {
+        animation: none;
+    }
+
+    ::view-transition-new(root) {
+        animation: theme-reveal 0.55s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+}


### PR DESCRIPTION
## Summary

- Theme toggle now triggers a circular reveal animation that expands from the button position
- Uses the View Transition API (`document.startViewTransition`) with CSS `clip-path: circle()` expanding from the toggle's center coordinates
- Falls back gracefully to instant toggle on browsers without View Transition support (Firefox)
- Respects `prefers-reduced-motion` — animation is skipped when reduced motion is enabled

## How it works

1. Click captures button center via `getBoundingClientRect()`
2. Coordinates are set as CSS custom properties (`--theme-toggle-x`, `--theme-toggle-y`) on `<html>`
3. `startViewTransition` captures old/new snapshots and animates `::view-transition-new(root)` with a circle expanding from those coordinates

## Browser support

- Chrome/Edge 111+ — full animation
- Safari 18+ — full animation
- Firefox — falls back to instant toggle (no View Transition support)